### PR TITLE
fix: Disable URL rewriting when creating links

### DIFF
--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -43,6 +43,8 @@ export default function TextEditor(props) {
         block_unsupported_drop: false,
         image_advtab: true,
         name: 'emailBody',
+        relative_urls : false,
+        remove_script_host : false,
       }}
       onEditorChange={onChange}
       value={value}


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
The default behavior of the TinyMCE editor is to rewrite links that share the same domain as the component to be relative to that path. Relative URLs will never work in email contents, so they _always_ need to be absolute URLs. This adds the configuration settings for `relative_urls` and `remove_script_host` in TinyMCE to always be false, enabling it to always use absolute URLs. See
[here](https://www.tiny.cloud/docs/configure/url-handling/) for reference.

# How can this be tested?
We will compile and deploy this to our QA environment for validation.